### PR TITLE
userTableにニックネームカラムを追加

### DIFF
--- a/db/migrate/20200304145504_add_nickname_to_users.rb
+++ b/db/migrate/20200304145504_add_nickname_to_users.rb
@@ -1,0 +1,5 @@
+class AddNicknameToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :nickname, :string, null: false, after: :id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_04_070213) do
+ActiveRecord::Schema.define(version: 2020_03_04_145504) do
 
   create_table "articles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id"
@@ -22,7 +22,18 @@ ActiveRecord::Schema.define(version: 2020_03_04_070213) do
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "article_id", null: false
+    t.text "comment", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["article_id"], name: "index_comments_on_article_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "nickname", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -35,4 +46,6 @@ ActiveRecord::Schema.define(version: 2020_03_04_070213) do
   end
 
   add_foreign_key "articles", "users"
+  add_foreign_key "comments", "articles"
+  add_foreign_key "comments", "users"
 end


### PR DESCRIPTION
# What
userTableにニックネームを追加する

# Why
ニックネームをユーザー情報に含めることでアカウントをニックネームで判別できるようになる。