### PR TITLE
記事一覧画面のページング実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,3 +65,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'devise'
 gem 'carrierwave'
 gem 'mini_magick'
+gem 'will_paginate'
+gem 'bootstrap-will_paginate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,8 @@ GEM
     bindex (0.8.1)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
+    bootstrap-will_paginate (1.0.0)
+      will_paginate
     builder (3.2.4)
     byebug (11.1.1)
     capybara (3.31.0)
@@ -214,6 +216,7 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    will_paginate (3.3.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -222,6 +225,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
+  bootstrap-will_paginate
   byebug
   capybara (>= 2.15)
   carrierwave
@@ -244,6 +248,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  will_paginate
 
 RUBY VERSION
    ruby 2.5.3p105

--- a/app/assets/stylesheets/articles/index.scss
+++ b/app/assets/stylesheets/articles/index.scss
@@ -76,3 +76,11 @@ p{
     }
   }
 }
+.pagination{
+  display:flex;
+  justify-content:center;
+  list-style: none;
+}
+li{
+  padding: 0 10px;
+}

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,6 +1,6 @@
 class ArticlesController < ApplicationController
   def index
-    @articles = Article.includes([user: :profile])
+    @articles = Article.includes([user: :profile]).paginate(page: params[:page], per_page: 5)
   end
   
   def new

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -21,5 +21,6 @@
         </div>
       <% end %>
     </div>
+    <%= will_paginate @articles, :previous_label => ' &lt 前へ', :next_label => '次へ &gt' %>
   </div>
 </div>


### PR DESCRIPTION
# What
記事一覧画面のページング実装

# Why
記事が多くなると一覧画面が見にくくなるので、ページングで一画面辺りに表示する記事数を制限する