### PR TITLE
未ログイン者のアクセス制限

### DIFF
--- a/app/assets/stylesheets/shared/_header.scss
+++ b/app/assets/stylesheets/shared/_header.scss
@@ -15,19 +15,22 @@ $base_color: #790604;
     color: white;
     text-decoration: none;
     position: absolute;
-    right: 100px;
+    right: 70px;
+    font-size: 10px;
   }
   &__new_account{
     color: white;
     text-decoration: none;
     position: absolute;
     right: 10px;
+    font-size: 10px;
   }
   &__my_page{
     color: white;
     text-decoration: none;
     position: absolute;
-    right: 180px;
+    right: 130px;
+    font-size: 10px;
   }
   &__new_article:hover{
     border-bottom: 1px white solid;

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,4 +1,7 @@
 class ArticlesController < ApplicationController
+  #指定したアクションはログインしてないと利用できない(ログイン画面に遷移される)
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
+  
   def index
     @articles = Article.includes([user: :profile]).paginate(page: params[:page], per_page: 5)
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,6 @@
 class CommentsController < ApplicationController
+  #指定したアクションはログインしてないと利用できない(ログイン画面に遷移される)
+  before_action :authenticate_user!, only: [:create]
   def create
     @comment = Comment.create(comment_params)
     redirect_to article_path(@comment.article)

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,4 +1,7 @@
 class ProfilesController < ApplicationController
+  #指定したアクションはログインしてないと利用できない(ログイン画面に遷移される)
+  before_action :authenticate_user!, only: [:edit, :update]
+
   def edit
     @user = User.find(params[:user_id])
     @profile = User.find(params[:user_id]).profile

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,7 @@
 <div class="header">
   <h2><%= link_to "appilcation", articles_path, class: "header__app_title" %></h2>
   <% if user_signed_in? %>
-    <%= link_to "マイページ", user_path(current_user.id), class: "header__my_page" %>
+    <%= link_to "#{current_user.nickname}さんのマイページ", user_path(current_user.id), class: "header__my_page" %>
     <%= link_to "ログアウト", destroy_user_session_path, class: "header__new_account", method: :delete %>
     <%= link_to "新規作成", new_article_path, class: "header__new_article" %>
   <% else%>


### PR DESCRIPTION
# What
未ログイン者がURLでログイン者用サービス画面にアクセスしても弾くようにする。

# Why
未ログイン者がURLを手動で書き換えることでログイン者用のサービス画面にアクセスできていた(レスポンスはエラーになる)。
もし未ログイン者がログイン者用のサービス画面にアクセスした場合、ログイン画面へリダイレクトするように実装する