### PR TITLE
記事一覧画面にカテゴリーの画像を表示

### DIFF
--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,5 +1,4 @@
-<div class="header__image">
-</div>
+<%= image_tag @category.image.url, class: "header__image" %>
 <%= render 'shared/header' %>
 <h1 class="category__title"><%= @category.category_name %></h1>
 <%= link_to 'topへ戻る', tops_path, style: "padding-left:30px;padding-top:30px;text-decoration:none;" %>


### PR DESCRIPTION
# What
記事一覧画面にカテゴリーの画像を表示
# Why
記事一覧画面に選択したカテゴリーの画像を表示することによって、現在ユーザーがどのカテゴリーの記事の一覧画面を選択しているのか視覚的にわかりやすくするため。