### PR TITLE
画像が本番環境でも表示される様にする

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,7 +1,7 @@
 <div class="comment">
   <div class="user_field">
     <% if comment.user.profile.user_image.url.nil? %>
-      <%= image_tag 'default.jpeg', class: "user_image" %>
+      <%= image_tag asset_url('default.jpg'), class: "user_image" %>
     <% else %>
       <%= image_tag comment.user.profile.user_image.url, class: "user_image" %>
     <% end %>


### PR DESCRIPTION
# What
画像が本番環境でも表示される様にする
# Why
記事の詳細画面のコメント欄でコメントしたユーザーのプロフィール画像が本番で表示できていなかったため修正