### PR TITLE
既存カラムのオプション変更

### DIFF
--- a/db/migrate/20200503132712_change_column_title_to_articles.rb
+++ b/db/migrate/20200503132712_change_column_title_to_articles.rb
@@ -1,0 +1,5 @@
+class ChangeColumnTitleToArticles < ActiveRecord::Migration[5.2]
+  def change
+    change_column :articles, :title, :string, index: true
+  end
+end

--- a/db/migrate/20200503133152_change_column_to_likes.rb
+++ b/db/migrate/20200503133152_change_column_to_likes.rb
@@ -1,0 +1,6 @@
+class ChangeColumnToLikes < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :likes, :article_id, false, 6
+    change_column_null :likes, :user_id, false, 8
+  end
+end

--- a/db/migrate/20200503133535_change_column_name_to_authorities.rb
+++ b/db/migrate/20200503133535_change_column_name_to_authorities.rb
@@ -1,0 +1,5 @@
+class ChangeColumnNameToAuthorities < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :authorities, :name, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_03_100429) do
+ActiveRecord::Schema.define(version: 2020_05_03_133535) do
 
   create_table "articles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "category_id", null: false
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 2020_05_03_100429) do
   end
 
   create_table "authorities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
   end
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -46,8 +46,8 @@ ActiveRecord::Schema.define(version: 2020_05_03_100429) do
   end
 
   create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "article_id"
-    t.bigint "user_id"
+    t.bigint "article_id", null: false
+    t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["article_id"], name: "index_likes_on_article_id"


### PR DESCRIPTION
# What
既存カラムのオプション変更
# Why
null許可してはいけないとこがnull許可になっていたり、記事の検索があるのに、検索対象のカラムにindexが貼っていない箇所があったため