### PR TITLE
初めてtwitterログインした時もprofileのデータが作成される様にする

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -12,7 +12,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def callback_from(provider)
     provider = provider.to_s
 
-    @user = User.find_for_oauth(request.env['omniauth.auth'])
+      @user = User.find_for_oauth(request.env['omniauth.auth'])
 
     if @user.persisted?
      flash[:notice] = "ログインしました。"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,14 +24,17 @@ class User < ApplicationRecord
   def self.find_for_oauth(auth)
     user = User.where(uid: auth.uid, provider: auth.provider).first
 
-    unless user
-      user = User.create(
-        uid:      auth.uid,
-        provider: auth.provider,
-        nickname: auth.info.nickname,
-        email:    User.dummy_email(auth),
-        password: Devise.friendly_token[0, 20]
-      )
+    ActiveRecord::Base.transaction do
+      unless user
+        user = User.create(
+          uid:      auth.uid,
+          provider: auth.provider,
+          nickname: auth.info.nickname,
+          email:    User.dummy_email(auth),
+          password: Devise.friendly_token[0, 20]
+        )
+        Profile.create(user_id: user.id)
+      end
     end
 
     user

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -25,7 +25,7 @@ Devise.setup do |config|
   if Rails.env.development?
     config.omniauth :twitter, Rails.application.credentials.dig(:twitter, :twitter_api_key), Rails.application.credentials.dig(:twitter, :twitter_api_secret_key), callback_url: "http://localhost:3000/users/auth/twitter/callback"
   elsif Rails.env.production?
-    config.omniauth :twitter, Rails.application.credentials.dig(:twitter, :twitter_api_key), Rails.application.credentials.dig(:twitter, :twitter_api_secret_key), callback_url: "http://13.230.224.20/users/auth/twitter/callback"
+    config.omniauth :twitter, Rails.application.credentials.dig(:twitter, :twitter_api_key), Rails.application.credentials.dig(:twitter, :twitter_api_secret_key), callback_url: "http://blogeeeeer.com/users/auth/twitter/callback"
   else
     config.omniauth :twitter, Rails.application.credentials.dig(:twitter, :twitter_api_key), Rails.application.credentials.dig(:twitter, :twitter_api_secret_key), callback_url: "http://localhost:3000/users/auth/twitter/callback"
   end


### PR DESCRIPTION
# What
初めてtwitterログインした時もprofileのデータが作成される様にする
# Why
twitterログイン者のprofileデータが作成されておらず、データの整合性が合わなくなっていたため